### PR TITLE
장애물을 회피하는 기능을 구현

### DIFF
--- a/self_drive/self_drive/self_drive_first.py
+++ b/self_drive/self_drive/self_drive_first.py
@@ -1,0 +1,53 @@
+import rclpy
+from rclpy.node import Node
+from rclpy.qos import QoSProfile
+from geometry_msgs.msg import Twist
+from sensor_msgs.msg import LaserScan
+
+
+class SelfDrive(Node):
+    def __init__(self):
+        super().__init__('self_drive')
+        lidar_qos_profile = QoSProfile(reliability=rclpy.qos.ReliabilityPolicy.BEST_EFFORT,
+                                       history=rclpy.qos.HistoryPolicy.KEEP_LAST,
+                                       depth=1)
+        vel_qos_profile = QoSProfile(depth=10)
+        self.sub_scan = self.create_subscription(
+            LaserScan,
+            '/scan',
+            self.subscribe_scan,
+            lidar_qos_profile)
+        self.pub_velo = self.create_publisher(Twist, '/cmd_vel', vel_qos_profile)
+        self.step = 0
+
+    def subscribe_scan(self, scan):
+        twist = Twist()
+
+        twist.linear.x = 0.15
+        twist.angular.z = 0.
+        self.get_logger().info(f"scan: {scan.ranges[0]}, forward")
+
+        if 0.01 < scan.ranges[10] <= 0.25 or 0.01 < scan.ranges[50] <= 0.25:
+            if 0.01 < scan.ranges[10] <= 0.23 or 0.01 < scan.ranges[30] <= 0.23:
+                twist.linear.x = 0.06
+                twist.angular.z = -1.2
+                self.get_logger().info(f"scan: {scan.ranges[30]}, right")
+            elif 0.01 < scan.ranges[30] <= 0.21 or 0.01 < scan.ranges[50] <= 0.21:
+                twist.linear.x = 0.08
+                twist.angular.z = -1.0
+                self.get_logger().info(f"scan: {scan.ranges[30]}, right")
+            else:
+                twist.linear.x = 0.03
+                twist.angular.z = -1.5
+       
+
+def main(args=None):
+    rclpy.init(args=args)
+    node = SelfDrive()
+    try:
+        rclpy.spin(node)
+    except KeyboardInterrupt:
+        node.get_logger().info('Keyboard Interrupt (SIGINT)')
+    finally:
+        node.destroy_node()
+        rclpy.shutdown()

--- a/self_drive/self_drive/self_drive_second.py
+++ b/self_drive/self_drive/self_drive_second.py
@@ -1,0 +1,50 @@
+import rclpy
+from rclpy.node import Node
+from rclpy.qos import QoSProfile
+from geometry_msgs.msg import Twist
+from sensor_msgs.msg import LaserScan
+
+
+class SelfDrive(Node):
+    def __init__(self):
+        super().__init__('self_drive')
+        lidar_qos_profile = QoSProfile(reliability=rclpy.qos.ReliabilityPolicy.BEST_EFFORT,
+                                       history=rclpy.qos.HistoryPolicy.KEEP_LAST,
+                                       depth=1)
+        vel_qos_profile = QoSProfile(depth=10)
+        self.sub_scan = self.create_subscription(
+            LaserScan,
+            '/scan',
+            self.subscribe_scan,
+            lidar_qos_profile)
+        self.pub_velo = self.create_publisher(Twist, '/cmd_vel', vel_qos_profile)
+        self.step = 0
+
+    def subscribe_scan(self, scan):
+       
+        if 0.01 < scan.ranges[350] <= 0.25 or 0.01 < scan.ranges[310] <= 0.25:
+            if 0.01 < scan.ranges[350] <= 0.23 or 0.01 < scan.ranges[330] <= 0.23:
+                twist.linear.x = 0.06
+                twist.angular.z = 1.2
+                self.get_logger().info(f"scan: {scan.ranges[330]}, left")
+            elif 0.01 < scan.ranges[330] <= 0.21 or 0.01 < scan.ranges[310] <= 0.21:
+                twist.linear.x = 0.08
+                twist.angular.z = 1.0
+                self.get_logger().info(f"scan: {scan.ranges[330]}, left")
+            else:
+                twist.linear.x = 0.03
+                twist.angular.z = 1.5
+
+        self.pub_velo.publish(twist)
+
+
+def main(args=None):
+    rclpy.init(args=args)
+    node = SelfDrive()
+    try:
+        rclpy.spin(node)
+    except KeyboardInterrupt:
+        node.get_logger().info('Keyboard Interrupt (SIGINT)')
+    finally:
+        node.destroy_node()
+        rclpy.shutdown()


### PR DESCRIPTION
Pull request를 하는 이유에는 자연스러운 코드 리뷰를 위해, push 권한이 없는 오픈 소스 프로젝트에 기여할때 등이 있습니다.
먼저 자율 주행을 위해 터틀봇이 이동하면서 1. 10도에서 50도 사이 2. 350도와 310도 사이 안에서 각도를 세분화 하여 LDS 센서에 25cm 이하의 경우에서 장애물이 감지되었을 경우 터틀봇이 장애물의 반대 방향으로 회전을 하며 장애물과 충돌을 피하기 위해 로봇의 x축과 z축의 속도를 조정하여 장애물을 피해서 움직이도록 구현하였습니다.  그리고 self_drive_first.py 와 self_drive_second.py 를 통해 구현하였고 최종적으로 self_drive.py에 장애물을 피해 가는 코드를 구현 하였습니다.
또, rclpy 기반 패키지는 pacakge.xml, setup.py 에서 패키지 설정을 할 수 있었으며 패키지 설정 파일에서 author, maintainer를 수정하여 사용하였습니다.